### PR TITLE
chore: Fixed version for the pre-downloaded libraries

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-rootfs-arduino-extra.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs-arduino-extra.yaml
@@ -202,10 +202,11 @@ actions:
       export ARDUINO_DIRECTORIES_DATA=/home/arduino/.arduino15 \
       && arduino-cli core install arduino:zephyr --additional-urls=https://arduino:aptexperiment@apt-repo.oniudra.cc/zephyr-core-imola.json \
       && arduino-cli cache clean \
-      && arduino-cli lib download MsgPack \
-      && arduino-cli lib download DebugLog \
-      && arduino-cli lib download ArxContainer \
-      && arduino-cli lib download ArxTypeTraits
+      && arduino-cli lib download MsgPack@0.4.2 \
+      && arduino-cli lib download DebugLog@0.8.4 \
+      && arduino-cli lib download ArxContainer@0.7.0 \
+      && arduino-cli lib download ArxTypeTraits@0.3.1 \
+      && arduino-cli lib download ArxTypeTraits@0.3.2
 
   - action: run
     description: Optimize toolchain


### PR DESCRIPTION
This allows you to run preinstalled examples offline, even if some libraries are updated over time.

Fix #8 