### PR TITLE
Jctl pinout fix

### DIFF
--- a/debos-recipes/overlays/arduino-unoq-releases/opt/arduino/scripts/volumedown.sh
+++ b/debos-recipes/overlays/arduino-unoq-releases/opt/arduino/scripts/volumedown.sh
@@ -9,9 +9,9 @@
 #
 #         MPU RESET   o  ■  GND
 #
-#                TX   o  o  VOLUME UP
+#                RX   o  o  VOLUME UP
 #
-#                RX   o  o  VOLUME DOWN
+#                TX   o  o  VOLUME DOWN
 #                        |
 #          USB BOOT   o  ■  GND
 

--- a/debos-recipes/overlays/arduino-unoq-releases/opt/arduino/scripts/volumeup.sh
+++ b/debos-recipes/overlays/arduino-unoq-releases/opt/arduino/scripts/volumeup.sh
@@ -9,9 +9,9 @@
 #
 #         MPU RESET   o  ■  GND
 #                        |
-#                TX   o  o  VOLUME UP
+#                RX   o  o  VOLUME UP
 #
-#                RX   o  o  VOLUME DOWN
+#                TX   o  o  VOLUME DOWN
 #
 #          USB BOOT   o  ■  GND
 


### PR DESCRIPTION
fix: swap TX and RX pin mapping in voumeup.sh & volumedown.sh comments

The JCTL connector pinout in the script header incorrectly mapped TX to
RX and RX to TX. This commit swaps them to reflect the
correct hardware configuration:
- RX -> TX
- TX -> RX

No functional code changes are made, only the documentation comment is
corrected.